### PR TITLE
fix: kustomize component url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ resources:
 
 components:
 # extensions controller component
-- https://github.com/argoproj-labs/argocd-extensions/manifests
+- https://github.com/argoproj-labs/argocd-extensions//manifests
 ```
 
 Store the YAML above into kustomization.yaml file and use the following command to install manifests:


### PR DESCRIPTION
According to https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md, the Kustomize example was wrong. 