### PR TITLE
Change patchesStrategicMerge to patches

### DIFF
--- a/manifests/argocd-server-patch/kustomization.yaml
+++ b/manifests/argocd-server-patch/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-patchesStrategicMerge:
-- argocd-server-deployment-patch.yaml
+patches:
+- path: argocd-server-deployment-patch.yaml


### PR DESCRIPTION
As of kustomize v5 patchesStrategicMerge has been depracated and building manifests with it will give warnings